### PR TITLE
Update __init__.py

### DIFF
--- a/viphoneme/__init__.py
+++ b/viphoneme/__init__.py
@@ -575,11 +575,13 @@ def vi2IPA_split(texts,delimit):
     
     return Results.rstrip()
 def vi2IPA(text):
-    #print("------------------------------------------------------")
-    TN= TTSnorm(text)
-    #print("------------------------------------------------------")
-    #print("Text normalize:              ",TN)
-    TK= word_tokenize(TN)
+
+    # Bỏ phần này để hoạt động với window
+    # TN= TTSnorm(text)
+    # Chuẩn hóa lại, tuy nhiên phần xử lý ngày tháng năm phải fix lại bằng text
+    text = text.lower()
+
+	TK= word_tokenize(TN)
     #print("Vietnamese Tokenize:         ",TK)
 
     #Trong trường hợp word_tokenize sai

--- a/viphoneme/__init__.py
+++ b/viphoneme/__init__.py
@@ -581,6 +581,13 @@ def vi2IPA(text):
     #print("Text normalize:              ",TN)
     TK= word_tokenize(TN)
     #print("Vietnamese Tokenize:         ",TK)
+
+    #Trong trường hợp word_tokenize sai
+    new_TK = []
+    for word in TK:
+        new_TK.extend(word.split())
+    TK = new_TK
+	
     IPA=""
     for tk in TK:
         ipa = T2IPA(tk).replace(" ","_")

--- a/viphoneme/__init__.py
+++ b/viphoneme/__init__.py
@@ -577,11 +577,11 @@ def vi2IPA_split(texts,delimit):
 def vi2IPA(text):
 
     # Bỏ phần này để hoạt động với window
-    # TN= TTSnorm(text)
+    TN= TTSnorm(text)
     # Chuẩn hóa lại, tuy nhiên phần xử lý ngày tháng năm phải fix lại bằng text
-    text = text.lower()
+    # text = text.lower()
 
-	TK= word_tokenize(TN)
+    TK= word_tokenize(TN)
     #print("Vietnamese Tokenize:         ",TK)
 
     #Trong trường hợp word_tokenize sai


### PR DESCRIPTION
Mình test thử trường hợp có tiếng Anh thì thấy bug về convert tiếng Anh

```
from viphoneme import vi2IPA
phoneme = vi2IPA("có thể xử lí những trường hợp chứa English tú")
phoneme
```
output:   kɔ5_tʰe4 sɯ4_li5 ɲɯŋ3 ʈɯəŋ2_hɤp6 cɯə5 [english]_tu5 .
Kỳ vọng: kɔ5 tʰe4 sɯ4 li5 ɲɯŋ3 ʈɯəŋ2 hɤp6 cɯə5 ˈɪŋlɪʃ tu5 .

Mình có check qua code thì bug ở phần word_tokenize của bên underthesea. 
['có thể', 'xử lí', 'những', 'trường hợp', 'chứa', '**english tú**', '.']

=> Giải pháp: Chỉnh lại mảng TK chứa từng từ riêng lẻ
